### PR TITLE
Fixed code to pass unit tests

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ pub(crate) struct Config {
   pub(crate) shell_args: Vec<String>,
   pub(crate) shell_command: bool,
   pub(crate) shell_present: bool,
+  pub(crate) shell_args_present: bool,
   pub(crate) subcommand: Subcommand,
   pub(crate) unsorted: bool,
   pub(crate) unstable: bool,
@@ -563,8 +564,9 @@ impl Config {
       Vec::new()
     };
 
-    let shell_present = matches.occurrences_of(arg::CLEAR_SHELL_ARGS) > 0
-      || matches.occurrences_of(arg::SHELL) > 0
+    let shell_present = matches.occurrences_of(arg::SHELL) > 0;
+
+    let shell_args_present = matches.occurrences_of(arg::CLEAR_SHELL_ARGS) > 0
       || matches.occurrences_of(arg::SHELL_ARG) > 0;
 
     Ok(Self {
@@ -590,6 +592,7 @@ impl Config {
       search_config,
       shell_args,
       shell_present,
+      shell_args_present,
       subcommand,
       dotenv_filename: matches.value_of(arg::DOTENV_FILENAME).map(str::to_owned),
       dotenv_path: matches.value_of(arg::DOTENV_PATH).map(PathBuf::from),
@@ -729,6 +732,7 @@ ARGS:
       $(shell: $shell:expr,)?
       $(shell_args: $shell_args:expr,)?
       $(shell_present: $shell_present:expr,)?
+      $(shell_args_present: $shell_args_present:expr,)?
       $(subcommand: $subcommand:expr,)?
       $(unsorted: $unsorted:expr,)?
       $(verbosity: $verbosity:expr,)?
@@ -749,6 +753,7 @@ ARGS:
           $(shell: $shell.to_owned(),)?
           $(shell_args: $shell_args,)?
           $(shell_present: $shell_present,)?
+          $(shell_args_present: $shell_args_present,)?
           $(subcommand: $subcommand,)?
           $(unsorted: $unsorted,)?
           $(verbosity: $verbosity,)?
@@ -1012,6 +1017,7 @@ ARGS:
     shell: "",
     shell_args: vec![],
     shell_present: false,
+    shell_args_present: false,
   }
 
   test! {
@@ -1019,6 +1025,15 @@ ARGS:
     args: ["--shell", "tclsh"],
     shell: "tclsh",
     shell_present: true,
+    shell_args_present: false,
+  }
+
+  test! {
+    name: shell_args_set,
+    args: ["--shell-arg", "hello"],
+    shell_args: vec!["hello".into()],
+    shell_present: false,
+    shell_args_present: true,
   }
 
   test! {
@@ -1262,49 +1277,56 @@ ARGS:
     name: shell_args_set_hyphen,
     args: ["--shell-arg", "--foo"],
     shell_args: vec!["--foo".to_owned()],
-    shell_present: true,
+    shell_present: false,
+    shell_args_present: true,
   }
 
   test! {
     name: shell_args_set_word,
     args: ["--shell-arg", "foo"],
     shell_args: vec!["foo".to_owned()],
-    shell_present: true,
+    shell_present: false,
+    shell_args_present: true,
   }
 
   test! {
     name: shell_args_set_multiple,
     args: ["--shell-arg", "foo", "--shell-arg", "bar"],
     shell_args: vec!["foo".to_owned(), "bar".to_owned()],
-    shell_present: true,
+    shell_present: false,
+    shell_args_present: true,
   }
 
   test! {
     name: shell_args_clear,
     args: ["--clear-shell-args"],
     shell_args: vec![],
-    shell_present: true,
+    shell_present: false,
+    shell_args_present: true,
   }
 
   test! {
     name: shell_args_clear_and_set,
     args: ["--clear-shell-args", "--shell-arg", "bar"],
     shell_args: vec!["bar".to_owned()],
-    shell_present: true,
+    shell_present: false,
+    shell_args_present: true,
   }
 
   test! {
     name: shell_args_set_and_clear,
     args: ["--shell-arg", "bar", "--clear-shell-args"],
     shell_args: vec![],
-    shell_present: true,
+    shell_present: false,
+    shell_args_present: true,
   }
 
   test! {
     name: shell_args_set_multiple_and_clear,
     args: ["--shell-arg", "bar", "--shell-arg", "baz", "--clear-shell-args"],
     shell_args: vec![],
-    shell_present: true,
+    shell_present: false,
+    shell_args_present: true,
   }
 
   test! {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -34,38 +34,54 @@ impl<'src> Settings<'src> {
   }
 
   pub(crate) fn shell_binary<'a>(&'a self, config: &'a Config) -> &'a str {
-    if config.shell_present {
-      return &config.shell;
-    }
+    // Order of precedence:
+    // 1) CLI argument (config)
+    // 2) Settings in justfile (settings)
+    // 3) Default/PowerShell
 
-    if cfg!(windows) && self.windows_powershell {
-      return WINDOWS_DEFAULT_SHELL;
-    }
+    // Restores old behaviour where when `--shell-arg` was given `--shell` or
+    // the default shell was used (overwriting `set shell` in justfiles).
+    let shell_or_args_present = config.shell_present | config.shell_args_present;
 
-    if let Some(shell) = &self.shell {
-      return shell.command.cooked.as_ref();
+    if let (Some(shell), false) = (&self.shell, shell_or_args_present) {
+      shell.command.cooked.as_ref()
+    } else if config.shell_present {
+      &config.shell
     } else {
-      return DEFAULT_SHELL;
+      // Default value for shell
+      if cfg!(windows) && self.windows_powershell {
+        WINDOWS_DEFAULT_SHELL
+      } else {
+        DEFAULT_SHELL
+      }
     }
   }
 
   pub(crate) fn shell_arguments<'a>(&'a self, config: &'a Config) -> Vec<&'a str> {
-    if config.shell_present {
-      return config.shell_args.iter().map(String::as_ref).collect();
-    }
+    // Order of precedence:
+    // 1) CLI argument (config)
+    // 2) Settings in justfile (settings)
+    // 3) Default/PowerShell
 
-    if cfg!(windows) && self.windows_powershell {
-      return vec![WINDOWS_DEFAULT_SHELL_ARG];
-    }
+    // Restores old behaviour where when `--shell` was given `--shell-arg` or
+    // the default shell args were used (overwriting `set shell` in justfiles).
+    let shell_or_args_present = config.shell_present | config.shell_args_present;
 
-    if let Some(shell) = &self.shell {
-      return shell
+    if let (Some(shell), false) = (&self.shell, shell_or_args_present) {
+      shell
         .arguments
         .iter()
         .map(|argument| argument.cooked.as_ref())
-        .collect();
+        .collect()
+    } else if config.shell_args_present {
+      config.shell_args.iter().map(String::as_ref).collect()
     } else {
-      return vec![DEFAULT_SHELL_ARG];
+      // Default value for shell
+      if cfg!(windows) && self.windows_powershell {
+        vec![WINDOWS_DEFAULT_SHELL_ARG]
+      } else {
+        vec![DEFAULT_SHELL_ARG]
+      }
     }
   }
 }
@@ -118,6 +134,7 @@ mod tests {
 
     let config = Config {
       shell_present: true,
+      shell_args_present: true,
       shell_command: true,
       shell: "lol".to_string(),
       shell_args: vec!["-nice".to_string()],
@@ -135,6 +152,7 @@ mod tests {
 
     let config = Config {
       shell_present: true,
+      shell_args_present: true,
       shell_command: true,
       shell: "lol".to_string(),
       shell_args: vec!["-nice".to_string()],
@@ -171,5 +189,27 @@ mod tests {
 
     assert_eq!(settings.shell_binary(&config), "asdf.exe");
     assert_eq!(settings.shell_arguments(&config), vec!["-nope"]);
+  }
+
+  #[test]
+  fn shell_args_present_but_not_shell() {
+    let mut settings = Settings::new();
+    settings.windows_powershell = true;
+
+    let config = Config {
+      shell_present: false,
+      shell_args_present: true,
+      shell_command: false,
+      shell_args: vec!["-nice".to_string()],
+      ..testing::config(&[])
+    };
+
+    if cfg!(windows) {
+      assert_eq!(settings.shell_binary(&config), "powershell.exe");
+      assert_eq!(settings.shell_arguments(&config), vec!["-nice"]);
+    } else {
+      assert_eq!(settings.shell_binary(&config), "sh");
+      assert_eq!(settings.shell_arguments(&config), vec!["-nice"]);
+    }
   }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -76,7 +76,7 @@ impl<'src> Settings<'src> {
     } else if config.shell_args_present {
       config.shell_args.iter().map(String::as_ref).collect()
     } else {
-      // Default value for shell
+      // Default value for shell-args
       if cfg!(windows) && self.windows_powershell {
         vec![WINDOWS_DEFAULT_SHELL_ARG]
       } else {

--- a/tests/choose.rs
+++ b/tests/choose.rs
@@ -128,7 +128,7 @@ fn invoke_error_function() {
     .stderr(if cfg!(windows) {
       "error: Chooser `/ -cu fzf` invocation failed: Access is denied. (os error 5)\n"
     } else {
-      "error: Chooser `/ fzf` invocation failed: Permission denied (os error 13)\n"
+      "error: Chooser `/ -cu fzf` invocation failed: Permission denied (os error 13)\n"
     })
     .status(EXIT_FAILURE)
     .shell(false)


### PR DESCRIPTION
# Also restored old behaviour

When either `--shell` or `--shell-arg` where given via cli then just would overwrite **both** shell related value (shell, shell-args) from `Settings` with the default/given values.

## Example

1)

```sh
just --shell-arg test
```
Would overwrite the shell with `sh` even when the justfile contained `set shell`.

2)

```sh
just --shell test
```
Would overwrite the shell-args with `-cu` even when the justfile contained `set shell`.

---

This behaviour could be easily corrected/changed with the new code (e.g. independent values/not overwriting if the other is set) if it is desired.
